### PR TITLE
Add ScandicWellness chatbot interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# cuddly-octo-spork
-uppdate a strong theme for supplements shop
+# ScandicWellness Chatbot
+
+En enkel, fristående webbapp som låter kunder få snabb rådgivning om vitaminer och kosttillskott via en chattbot.
+
+## Kom igång
+
+1. Öppna `index.html` i din webbläsare, eller starta en enkel server:
+   ```bash
+   python -m http.server 8000
+   ```
+2. Surfa till `http://localhost:8000` och börja chatta med ScandicBot.
+
+## Funktioner
+
+- Färdiga svar för vanliga frågor om frakt, prenumeration och kundtjänst.
+- Produktrekommendationer baserade på nyckelord inom energi, immunförsvar, återhämtning m.m.
+- Snabbknappar för populära frågor och ett modernt, responsivt gränssnitt.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ScandicWellness Chatbot</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <main class="app">
+        <header class="app__header">
+            <h1>ScandicWellness</h1>
+            <p>Din digitala coach för vitaminer och kosttillskott</p>
+        </header>
+
+        <section class="chat" aria-live="polite">
+            <div class="chat__messages" id="chatMessages"></div>
+            <div class="chat__suggestions" id="chatSuggestions" aria-label="Snabbrekommendationer"></div>
+            <form class="chat__form" id="chatForm" aria-label="Skicka meddelande till ScandicWellness chatbot">
+                <label class="chat__label" for="userInput">Skriv din fråga</label>
+                <div class="chat__input-wrapper">
+                    <input type="text" id="userInput" name="userInput" placeholder="Fråga om produkter, leverans eller råd" autocomplete="off" required>
+                    <button type="submit" class="chat__send">Skicka</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="info">
+            <h2>Så fungerar chatten</h2>
+            <ul>
+                <li>Få snabba svar om vitaminer, mineraler och wellnessprogram.</li>
+                <li>Be om rekommendationer efter mål som energi, immunförsvar eller återhämtning.</li>
+                <li>Få hjälp med beställningar, frakt och prenumerationer.</li>
+            </ul>
+        </section>
+    </main>
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,208 @@
+const suggestions = [
+    "Tips för energi",
+    "Immunförsvar",
+    "Leveransalternativ",
+    "Prenumeration",
+    "Veganska produkter",
+    "Återhämtning efter träning"
+];
+
+const productCatalog = [
+    {
+        name: "Nordic Energy+ Multivitamin",
+        tags: ["energi", "multivitamin", "stress", "trött"],
+        description: "Balanserad multivitamin med B12, järn och adaptogener för jämn energi.",
+        usage: "1 tablett till frukost",
+        price: "249 kr",
+        benefits: ["Minskar trötthet", "Stödjer nervsystemet", "Passar vid stressiga perioder"]
+    },
+    {
+        name: "Polar D3 Forte",
+        tags: ["d-vitamin", "vitamin d", "immunförsvar", "skelett"],
+        description: "D-vitamin i oljelösning för bästa upptag, idealiskt under mörka månader.",
+        usage: "5 droppar dagligen tillsammans med måltid",
+        price: "189 kr",
+        benefits: ["Stödjer immunförsvar", "Bidrar till starkt skelett", "Innehåller MCT-olja"]
+    },
+    {
+        name: "Scandic Omega-3 Pure",
+        tags: ["omega", "hjärta", "fiskolja", "led"],
+        description: "Renad omega-3 från hållbart fiskeri med EPA och DHA.",
+        usage: "2 kapslar dagligen",
+        price: "219 kr",
+        benefits: ["Främjar hjärthälsa", "Stödjer hjärnans funktion", "Lindrar stela leder"]
+    },
+    {
+        name: "Recovery Plant Protein",
+        tags: ["protein", "träning", "återhämtning", "vegansk"],
+        description: "Komplett växtbaserat protein med aminosyror och magnesium för muskler.",
+        usage: "1 skopa i vatten eller smoothie efter träning",
+        price: "299 kr",
+        benefits: ["Snabb återhämtning", "Mjuk mot magen", "Berikat med vitamin C"]
+    },
+    {
+        name: "Calm Focus Magnesium",
+        tags: ["magnesium", "sömn", "stress", "återhämtning"],
+        description: "Magnesiumbisglycinat som tas upp skonsamt och hjälper till att varva ned.",
+        usage: "2 kapslar på kvällen",
+        price: "199 kr",
+        benefits: ["Avslappning i muskler", "Främjar god sömn", "Minskar stresskänslighet"]
+    },
+    {
+        name: "Nordic Kids Multidrops",
+        tags: ["barn", "familj", "vitamin", "drops"],
+        description: "Smidiga droppar med vitamin A, C, D och zink för hela familjen.",
+        usage: "5 droppar i dryck eller gröt",
+        price: "159 kr",
+        benefits: ["Stödjer immunförsvar", "Sockerfri", "Enkel dosering"]
+    }
+];
+
+const knowledgeBase = [
+    {
+        triggers: ["hej", "hejsan", "hallå", "tjena"],
+        response: () => "Hej! Jag är ScandicBot. Hur kan jag stötta dig i din hälsorutin idag?"
+    },
+    {
+        triggers: ["frakt", "leverans", "shipping"],
+        response: () => "Vi levererar inom 1-3 arbetsdagar med klimatkompenserad frakt. Fri frakt över 499 kr och du kan spåra paketet via din orderbekräftelse."
+    },
+    {
+        triggers: ["öppet köp", "retur", "returer"],
+        response: () => "Självklart! Du har 30 dagars öppet köp. Kontakta support@scandicwellness.se med ditt ordernummer så hjälper vi dig med en returfraktsedel."
+    },
+    {
+        triggers: ["prenumeration", "subscription"],
+        response: () => "Med en prenumeration får du 10% rabatt och leverans var 4:e eller 8:e vecka. Du kan pausa eller ändra i din kundprofil utan bindningstid."
+    },
+    {
+        triggers: ["betalning", "klarna", "swish"],
+        response: () => "Vi erbjuder betalning via kort, Swish och Klarna (faktura/delbetalning). Allt sker över krypterade betalningsflöden för din trygghet."
+    },
+    {
+        triggers: ["kontakt", "kundtjänst", "support"],
+        response: () => "Du når oss via chatten här, e-post support@scandicwellness.se eller telefon 010-123 45 67 vardagar 9-17."
+    }
+];
+
+const fallbackMessages = [
+    "Berätta gärna lite mer så ska jag guida dig rätt!",
+    "Jag hittar inte exakt svar – kan du beskriva din fråga lite tydligare?",
+    "Jag är ännu under upplärning. Vill du ha hjälp av en rådgivare kan jag ordna kontakt."
+];
+
+const chatMessages = document.getElementById("chatMessages");
+const chatForm = document.getElementById("chatForm");
+const userInput = document.getElementById("userInput");
+const suggestionsContainer = document.getElementById("chatSuggestions");
+
+function formatTime(date) {
+    return date.toLocaleTimeString("sv-SE", {
+        hour: "2-digit",
+        minute: "2-digit"
+    });
+}
+
+function createMessageElement(text, author) {
+    const wrapper = document.createElement("div");
+    wrapper.className = `message message--${author}`;
+
+    const bubble = document.createElement("div");
+    bubble.className = "message__bubble";
+    bubble.textContent = text;
+
+    const time = document.createElement("time");
+    time.className = "message__time";
+    time.dateTime = new Date().toISOString();
+    time.textContent = formatTime(new Date());
+
+    wrapper.append(bubble, time);
+    return wrapper;
+}
+
+function scrollToBottom() {
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+}
+
+function addMessage(text, author = "bot") {
+    const element = createMessageElement(text, author);
+    chatMessages.appendChild(element);
+    scrollToBottom();
+}
+
+function matchKnowledgeBase(message) {
+    const normalized = message.toLowerCase();
+    for (const entry of knowledgeBase) {
+        if (entry.triggers.some(trigger => normalized.includes(trigger))) {
+            return entry.response();
+        }
+    }
+    return null;
+}
+
+function findProductRecommendation(message) {
+    const normalized = message.toLowerCase();
+    const matches = productCatalog.filter(product =>
+        product.tags.some(tag => normalized.includes(tag))
+    );
+
+    if (!matches.length) {
+        return null;
+    }
+
+    const topProduct = matches[0];
+    const benefits = topProduct.benefits.map(b => `• ${b}`).join("\n");
+
+    return `Jag rekommenderar ${topProduct.name}. ${topProduct.description}\n\nSå använder du den: ${topProduct.usage}.\nPris: ${topProduct.price}.\n\nFördelar:\n${benefits}`;
+}
+
+function buildSuggestionButtons() {
+    suggestions.forEach(text => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "suggestion";
+        button.textContent = text;
+        button.addEventListener("click", () => {
+            userInput.value = text;
+            userInput.focus();
+        });
+        suggestionsContainer.appendChild(button);
+    });
+}
+
+function handleUserMessage(message) {
+    addMessage(message, "user");
+
+    const knowledgeReply = matchKnowledgeBase(message);
+    if (knowledgeReply) {
+        setTimeout(() => addMessage(knowledgeReply, "bot"), 400);
+        return;
+    }
+
+    const productReply = findProductRecommendation(message);
+    if (productReply) {
+        setTimeout(() => addMessage(productReply, "bot"), 400);
+        return;
+    }
+
+    const fallback = fallbackMessages[Math.floor(Math.random() * fallbackMessages.length)];
+    setTimeout(() => addMessage(fallback, "bot"), 400);
+}
+
+function handleFormSubmit(event) {
+    event.preventDefault();
+    const message = userInput.value.trim();
+    if (!message) {
+        return;
+    }
+    userInput.value = "";
+    handleUserMessage(message);
+}
+
+function init() {
+    buildSuggestionButtons();
+    addMessage("Hej! Jag är ScandicBot – din guide till vitaminer och kosttillskott. Vad vill du veta idag?", "bot");
+    chatForm.addEventListener("submit", handleFormSubmit);
+}
+
+init();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,209 @@
+:root {
+    color-scheme: light;
+    --bg: #f5f7fa;
+    --primary: #004f6d;
+    --accent: #66c4d8;
+    --text: #102026;
+    --muted: #5a6b74;
+    --surface: #ffffff;
+    --surface-alt: #e6f3f6;
+    font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(135deg, var(--bg), var(--surface-alt));
+    color: var(--text);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 2rem 1rem;
+}
+
+.app {
+    background: var(--surface);
+    border-radius: 24px;
+    max-width: 960px;
+    width: 100%;
+    padding: 2rem;
+    box-shadow: 0 24px 55px rgba(16, 32, 38, 0.15);
+    display: grid;
+    gap: 2rem;
+}
+
+.app__header {
+    text-align: center;
+}
+
+.app__header h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary);
+}
+
+.app__header p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.chat {
+    display: grid;
+    gap: 1rem;
+    background: var(--surface-alt);
+    border-radius: 18px;
+    padding: 1.5rem;
+}
+
+.chat__messages {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-height: 380px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+    scroll-behavior: smooth;
+}
+
+.message {
+    display: grid;
+    gap: 0.25rem;
+    max-width: 90%;
+}
+
+.message--bot {
+    justify-self: flex-start;
+}
+
+.message--user {
+    justify-self: flex-end;
+    text-align: right;
+}
+
+.message__bubble {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    line-height: 1.4;
+    font-size: 0.95rem;
+    background: #ffffff;
+    color: var(--text);
+}
+
+.message--bot .message__bubble {
+    background: var(--primary);
+    color: white;
+}
+
+.message__time {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.chat__suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.suggestion {
+    background: white;
+    border: 1px solid var(--accent);
+    color: var(--primary);
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.suggestion:hover,
+.suggestion:focus {
+    background: var(--primary);
+    color: white;
+    outline: none;
+}
+
+.chat__form {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.chat__label {
+    font-weight: 600;
+}
+
+.chat__input-wrapper {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.chat__input-wrapper input {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid #c5d5dc;
+    font-size: 1rem;
+}
+
+.chat__input-wrapper input:focus {
+    border-color: var(--primary);
+    outline: 3px solid rgba(102, 196, 216, 0.4);
+}
+
+.chat__send {
+    background: var(--primary);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat__send:hover,
+.chat__send:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(0, 79, 109, 0.25);
+}
+
+.info {
+    background: white;
+    border-radius: 18px;
+    padding: 1.5rem;
+    border: 1px solid #e0e8ec;
+}
+
+.info h2 {
+    margin-top: 0;
+    color: var(--primary);
+}
+
+.info ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+    body {
+        padding: 1.5rem 1rem;
+    }
+
+    .app {
+        padding: 1.5rem;
+    }
+
+    .chat__messages {
+        max-height: 320px;
+    }
+}


### PR DESCRIPTION
## Summary
- add standalone ScandicWellness chatbot landing page with chat layout and info section
- style the experience with a responsive wellness-inspired theme and suggestion chips
- implement lightweight rule-based chat logic with product tips and update README usage notes

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_b_68f07ea84ba883218e753d90100cd98d