### PR TITLE
Embed Webbkompassen logo in site header

### DIFF
--- a/assets/webbkompassen-logo.svg
+++ b/assets/webbkompassen-logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" role="img" aria-labelledby="title desc">
+  <title id="title">Webbkompassen logotyp</title>
+  <desc id="desc">Vit kompassikon och text på blå bakgrundsgradient</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0b3d91" />
+      <stop offset="50%" stop-color="#0d6cc6" />
+      <stop offset="100%" stop-color="#1b9ad7" />
+    </linearGradient>
+  </defs>
+  <rect width="500" height="500" fill="url(#bg)" />
+  <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M90 280c38-84 122-140 210-140s172 56 210 140" />
+    <path d="M90 280h320" />
+    <path d="M250 120v220" />
+  </g>
+  <g fill="#ffffff">
+    <path d="M250 120l-36 190 36-52 36 52-36-190z" />
+    <path d="M250 168l-78 126 78-62 78 62-78-126z" />
+    <path d="M250 214l-120 82 120-46 120 46-120-82z" />
+    <circle cx="250" cy="280" r="14" />
+    <circle cx="166" cy="280" r="8" />
+    <circle cx="334" cy="280" r="8" />
+  </g>
+  <g fill="#ffffff" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="250" y="350" font-size="46" font-weight="600" letter-spacing="4">WEBBKOMPASSEN</text>
+    <text x="250" y="392" font-size="20" letter-spacing="6">DIN DIGITALA FRAMGÅNG</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Webbkompassen – Shopifyexperter för den svenska marknaden</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-content">
+      <a href="#top" class="logo" aria-label="Webbkompassen startsida">
+        <img src="assets/webbkompassen-logo.svg" alt="Webbkompassen logotyp">
+      </a>
+      <nav class="main-nav" aria-label="Huvudmeny">
+        <a href="#tjanster">Tjänster</a>
+        <a href="#process">Process</a>
+        <a href="#case">Kundcase</a>
+        <a href="#verktyg">Verktyg</a>
+        <a href="#kontakt" class="nav-cta">Boka möte</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="top">
+    <section class="hero">
+      <div class="container hero-content">
+        <div class="hero-text">
+          <span class="badge">Shopify-partner för svenska e-handlare</span>
+          <h1>Skala din Shopify-butik med ett team som förstår svensk e-handel</h1>
+          <p>Webbkompassen guidar dig från första skiss till full fart i försäljningen. Vi bygger butiker, optimerar SEO och driver kampanjer med datadrivna verktyg – utan genvägar eller AI-gissningar.</p>
+          <div class="hero-actions">
+            <a href="#kontakt" class="btn primary">Boka strategi-samtal</a>
+            <a href="#tjanster" class="btn secondary">Utforska våra tjänster</a>
+          </div>
+          <div class="social-proof">
+            <p>Förtroende från entreprenörer inom mode, hälsa och premiumvaror.</p>
+          </div>
+        </div>
+        <div class="hero-card" role="presentation">
+          <div class="hero-card-inner">
+            <h2>Färdplan för tillväxt</h2>
+            <ul>
+              <li><strong>1.</strong> Workshop &amp; konkurrentanalys</li>
+              <li><strong>2.</strong> Design &amp; Shopify-implementation</li>
+              <li><strong>3.</strong> SEO-plan med Semrush &amp; Search Console</li>
+              <li><strong>4.</strong> Performance marketing &amp; rapportering</li>
+            </ul>
+            <p class="card-footer">Klara resultat på 90 dagar – tydliga KPI:er varje vecka.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="tjanster" class="section services">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Tjänster som ger mätbara resultat</h2>
+          <p>Allt paketerat för svenska varumärken som vill växa sin Shopify-butik.</p>
+        </div>
+        <div class="service-grid">
+          <article class="service-card">
+            <h3>Shopify-byggen &amp; migreringar</h3>
+            <p>Från design wireframes till färdig konverterande butik. Vi optimerar checkout, betalflöden och integrerar lagersystem samt Klarna.</p>
+            <ul>
+              <li>Anpassade teman &amp; Shopify 2.0</li>
+              <li>Migration från WooCommerce eller Magento</li>
+              <li>Conversion rate-optimering (CRO)</li>
+            </ul>
+          </article>
+          <article class="service-card">
+            <h3>SEO &amp; innehåll</h3>
+            <p>Svenskspråkiga produktsidor och guider som driver trafik. Vi använder Semrush, Screaming Frog och Search Console för att hitta luckor.</p>
+            <ul>
+              <li>Teknisk SEO &amp; Core Web Vitals</li>
+              <li>Innehållskalender &amp; copywriting</li>
+              <li>Löpande rapporter med tydliga KPI:er</li>
+            </ul>
+          </article>
+          <article class="service-card">
+            <h3>Performance marketing</h3>
+            <p>Datadrivna kampanjer i Google Ads, Meta och e-postflöden. Vi testar, optimerar och rapporterar varje vecka.</p>
+            <ul>
+              <li>Full funnel-strategi &amp; remarketing</li>
+              <li>Kreativt material &amp; A/B-testning</li>
+              <li>Attribution och ROAS-analys</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section highlight">
+      <div class="container highlight-grid">
+        <div>
+          <h2>Varför Webbkompassen?</h2>
+          <p>Vi är ett hands-on team med bakgrund inom svensk detaljhandel. Våra projekt drivs av riktiga data och verktyg som Semrush, Ahrefs, Hotjar och GA4. Du arbetar direkt med seniora specialister – inget fluff.</p>
+        </div>
+        <ul class="pill-list">
+          <li>Transparens &amp; veckovisa standups</li>
+          <li>Fasta paket eller skräddarsydd retainer</li>
+          <li>Partnerskap med Shopify Experts</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="process" class="section process">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Så arbetar vi tillsammans</h2>
+          <p>Strukturerat, mätbart och anpassat för den svenska marknaden.</p>
+        </div>
+        <div class="timeline">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>Analys &amp; strategi</h3>
+            <p>Workshop kring mål, målgrupper och konkurrenter. Vi använder Semrush och GA4 för att kartlägga möjligheter.</p>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>Design &amp; byggnation</h3>
+            <p>Prototyper, UX-design och utveckling i Shopify 2.0. Integrering med svenska betal- och logistiklösningar.</p>
+          </div>
+          <div class="step">
+            <div class="step-number">3</div>
+            <h3>Lansering &amp; optimering</h3>
+            <p>SEO-granskning, tracking, kampanjplanering och utbildning av ditt team.</p>
+          </div>
+          <div class="step">
+            <div class="step-number">4</div>
+            <h3>Tillväxt &amp; rapportering</h3>
+            <p>Löpande förbättringar med tydliga rapporter och dashboards. Fokus på konvertering, retention och ROAS.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="case" class="section cases">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Kundcase &amp; resultat</h2>
+          <p>Utvalda samarbeten där vi stöttat svenska varumärken till nästa nivå.</p>
+        </div>
+        <div class="case-grid">
+          <article class="case-card">
+            <h3>Nordiska Natur</h3>
+            <p>Ny Shopify-butik med fokus på prenumerationer och storytelling. +68% i konverteringsgrad på tre månader.</p>
+          </article>
+          <article class="case-card">
+            <h3>Stockholm Sneakers</h3>
+            <p>Migrering från Magento, snabbare laddtider och automatiserade kampanjer. 4,3x ROAS i Meta Ads.</p>
+          </article>
+          <article class="case-card">
+            <h3>Luna Skincare</h3>
+            <p>SEO-strategi och innehållssatsning för nya produkter. 120% ökad organisk trafik på sex månader.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="verktyg" class="section tools">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Verktyg &amp; teknikstack</h2>
+          <p>Vi väljer beprövade verktyg som ger tydliga insikter och snabb implementering.</p>
+        </div>
+        <div class="tool-list">
+          <div class="tool">Shopify 2.0</div>
+          <div class="tool">Klaviyo</div>
+          <div class="tool">Semrush</div>
+          <div class="tool">Google Analytics 4</div>
+          <div class="tool">Screaming Frog</div>
+          <div class="tool">Hotjar</div>
+          <div class="tool">Meta Ads Manager</div>
+          <div class="tool">Looker Studio</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta">
+      <div class="container cta-content">
+        <div>
+          <h2>Redo att accelerera din Shopify-butik?</h2>
+          <p>Boka ett kostnadsfritt strategi-samtal så går vi igenom nuläge, potential och konkreta nästa steg.</p>
+        </div>
+        <a href="#kontakt" class="btn primary">Boka möte</a>
+      </div>
+    </section>
+
+    <section id="kontakt" class="section contact">
+      <div class="container contact-grid">
+        <div>
+          <h2>Kontakta Webbkompassen</h2>
+          <p>Berätta om dina mål så återkommer vi inom en arbetsdag.</p>
+          <ul class="contact-details">
+            <li><strong>E-post:</strong> hej@webbkompassen.se</li>
+            <li><strong>Telefon:</strong> +46 (0)8 123 45 678</li>
+            <li><strong>Adress:</strong> Vasagatan 12, 111 20 Stockholm</li>
+          </ul>
+        </div>
+        <form class="contact-form" aria-label="Kontaktformulär">
+          <label for="name">Namn</label>
+          <input type="text" id="name" name="name" placeholder="Ditt namn" required>
+
+          <label for="email">E-post</label>
+          <input type="email" id="email" name="email" placeholder="namn@företag.se" required>
+
+          <label for="company">Företag</label>
+          <input type="text" id="company" name="company" placeholder="Företag eller varumärke">
+
+          <label for="message">Vad behöver du hjälp med?</label>
+          <textarea id="message" name="message" rows="4" placeholder="Beskriv projektet" required></textarea>
+
+          <button type="submit" class="btn primary">Skicka</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-content">
+      <p>&copy; <span id="year"></span> Webbkompassen. Alla rättigheter förbehållna.</p>
+      <a href="mailto:hej@webbkompassen.se">hej@webbkompassen.se</a>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,464 @@
+:root {
+  --bg: #0b1120;
+  --bg-alt: #10182f;
+  --accent: #33d6a6;
+  --accent-dark: #28b089;
+  --text: #f5f7fa;
+  --muted: #a7b0c4;
+  --card-bg: rgba(16, 24, 47, 0.75);
+  --border: rgba(255, 255, 255, 0.1);
+  --gradient: linear-gradient(135deg, #2d6cdf 0%, #2dd6c1 100%);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(11, 17, 32, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
+.logo img {
+  height: 48px;
+  width: auto;
+  display: block;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(12, 24, 44, 0.3);
+}
+
+.main-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.main-nav a {
+  font-weight: 500;
+  color: var(--muted);
+  transition: color 0.2s ease;
+}
+
+.main-nav a:hover,
+.main-nav a:focus {
+  color: var(--text);
+}
+
+.nav-cta {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+}
+
+.nav-cta:hover,
+.nav-cta:focus {
+  background: var(--accent);
+  color: #03121a;
+}
+
+.hero {
+  padding: 6rem 0 5rem;
+  background: radial-gradient(circle at top left, rgba(45, 108, 223, 0.3), transparent 50%),
+              radial-gradient(circle at top right, rgba(45, 214, 193, 0.25), transparent 55%);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  margin: 1rem 0;
+}
+
+.hero-text p {
+  color: var(--muted);
+  max-width: 36ch;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(45, 214, 193, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 2rem 0 1.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: 0.9rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.primary {
+  background: var(--gradient);
+  color: #041220;
+  box-shadow: 0 10px 30px rgba(45, 214, 193, 0.3);
+}
+
+.btn.primary:hover,
+.btn.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(45, 214, 193, 0.45);
+}
+
+.btn.secondary {
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.social-proof {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero-card {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-card-inner {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(3, 12, 26, 0.35);
+  max-width: 360px;
+}
+
+.hero-card-inner h2 {
+  font-size: 1.3rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-card-inner ul {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.hero-card-inner li strong {
+  color: var(--accent);
+  margin-right: 0.6rem;
+}
+
+.card-footer {
+  margin-top: 2rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+.section-heading {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto 3rem;
+}
+
+.section-heading h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  margin-bottom: 1rem;
+}
+
+.section-heading p {
+  color: var(--muted);
+}
+
+.service-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1.4rem;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.service-card:hover,
+.service-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(51, 214, 166, 0.6);
+}
+
+.service-card p {
+  color: var(--muted);
+}
+
+.service-card ul {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.highlight {
+  background: var(--bg-alt);
+}
+
+.highlight-grid {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.pill-list {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.pill-list li {
+  background: rgba(51, 214, 166, 0.12);
+  color: var(--accent);
+  padding: 0.9rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.step {
+  background: var(--card-bg);
+  border-radius: 1.4rem;
+  border: 1px solid var(--border);
+  padding: 2rem;
+  position: relative;
+}
+
+.step-number {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  background: var(--gradient);
+  color: #041220;
+  border-radius: 999px;
+  font-weight: 700;
+  margin-bottom: 1.3rem;
+}
+
+.step p {
+  color: var(--muted);
+}
+
+.cases {
+  background: radial-gradient(circle at center, rgba(51, 214, 166, 0.12), transparent 65%);
+}
+
+.case-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.case-card {
+  background: rgba(16, 24, 47, 0.7);
+  border-radius: 1.2rem;
+  border: 1px solid var(--border);
+  padding: 2rem;
+  color: var(--muted);
+  min-height: 180px;
+}
+
+.case-card h3 {
+  color: var(--text);
+  margin-bottom: 0.8rem;
+}
+
+.tools .tool-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.tool {
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.cta {
+  background: var(--gradient);
+  color: #041220;
+}
+
+.cta-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.contact {
+  background: var(--bg-alt);
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+}
+
+.contact-details {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--muted);
+  margin-top: 1.5rem;
+}
+
+.contact-form {
+  background: var(--card-bg);
+  border-radius: 1.4rem;
+  border: 1px solid var(--border);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-form label {
+  font-weight: 500;
+}
+
+.contact-form input,
+.contact-form textarea {
+  background: rgba(11, 17, 32, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.8rem;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 2px solid rgba(51, 214, 166, 0.6);
+  border-color: transparent;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  background: rgba(11, 17, 32, 0.95);
+}
+
+.footer-content {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .logo img {
+    height: 40px;
+  }
+
+  .main-nav {
+    display: none;
+  }
+
+  .site-header {
+    position: static;
+  }
+
+  .hero {
+    padding-top: 4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Webbkompassen logotype asset with blue gradient background
- display the logo in the site header and style it for desktop and mobile breakpoints

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68f91b43fbcc8321bb65357fc17c8b72