### PR TITLE
Add Swedish SEO platform MVP plan and mock implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Run pytest
+        run: pytest
+        working-directory: backend
+  test-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+        working-directory: frontend
+      - name: Run tests
+        run: npm run test -- --watch=false
+        working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+backend/.venv/
+frontend/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,17 +1,63 @@
-# ScandicWellness Chatbot
+# Svensk SEO-plattform – Semrush-modell för Google.se
 
-En enkel, fristående webbapp som låter kunder få snabb rådgivning om vitaminer och kosttillskott via en chattbot.
+Denna repo innehåller en MVP-prototyp av en svensk SEO-plattform med mockad data. Lösningen inkluderar produktplan (PRD), systemdesign, FastAPI-backend, Next.js-frontend, rapportexempel, tester och CI-pipeline.
 
-## Kom igång
+## Innehåll
+- `docs/` – PRD, arkitektur, algoritmer, UX, testplan, GDPR, backlog.
+- `backend/` – FastAPI-app med mockade endpointar.
+- `frontend/` – Next.js-gränssnitt på svenska.
+- `reports/` – Exempelrapporter (Markdown + CSV-schema).
+- `.github/workflows/ci.yml` – GitHub Actions-pipeline.
 
-1. Öppna `index.html` i din webbläsare, eller starta en enkel server:
-   ```bash
-   python -m http.server 8000
-   ```
-2. Surfa till `http://localhost:8000` och börja chatta med ScandicBot.
+## Krav & installation
 
-## Funktioner
+### Backend (lokalt)
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn backend.app.main:app --reload
+```
+Backend exponeras på `http://localhost:8000` med Swagger på `/docs`.
 
-- Färdiga svar för vanliga frågor om frakt, prenumeration och kundtjänst.
-- Produktrekommendationer baserade på nyckelord inom energi, immunförsvar, återhämtning m.m.
-- Snabbknappar för populära frågor och ett modernt, responsivt gränssnitt.
+### Frontend (lokalt)
+```bash
+cd frontend
+npm install
+npm run dev
+```
+Frontend lyssnar på `http://localhost:3000` och anropar backend på `localhost:8000`.
+
+### Docker (kombinerad)
+> TODO i v2: docker-compose för backend/worker/frontend.
+
+## Miljövariabler
+- `DB_URL` – PostgreSQL-anslutning (Mock i MVP).
+- `REDIS_URL` – Redis för cache/kö.
+- `JWT_SECRET` – Hemlighet för JWT-signering.
+- `API_KEYS_*` – Integrationer (Search Console, Ads m.fl.).
+
+## Testning
+```bash
+# Backend
+cd backend
+pytest
+
+# Frontend
+cd frontend
+npm install
+npm run test
+```
+
+## Deploy-strategi
+- Backend → Railway (FastAPI + PostgreSQL + Redis).
+- Frontend → Vercel (Next.js).
+- Worker → Railway (Celery + Redis).
+
+## GDPR & Säkerhet
+Se `docs/gdpr_security.md` för processer kring dataminimering, samtycke och incidentrespons.
+
+## Rapportexport
+Rapporter i `reports/` kan konverteras till PDF med exempelvis `pandoc`.
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from . import services
+
+app = FastAPI(
+    title="Svensk SEO-plattform API",
+    description="Mockat FastAPI-backend för svensk Semrush-modell",
+    version="0.1.0",
+)
+
+
+class KeywordQuery(BaseModel):
+    query: str
+    project_id: str | None = None
+
+
+class KeywordResult(BaseModel):
+    keyword: str
+    search_volume: int
+    kd_se: float
+    cpc_sek: float
+    trend: List[int]
+    serp_features: List[str]
+
+
+class DomainCompareRequest(BaseModel):
+    primary_domain: str
+    competitor_domains: List[str]
+
+
+class AuditStartRequest(BaseModel):
+    domain: str
+
+
+class ContentBriefRequest(BaseModel):
+    keyword: str
+    competitors: List[str] = Field(default_factory=list)
+    tone: str = "Professionell och hjälpsam"
+    cta_type: str = "Boka konsultation"
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}
+
+
+@app.post("/keywords/search", response_model=List[KeywordResult])
+def keywords_search(payload: KeywordQuery) -> List[KeywordResult]:
+    return services.search_keywords(payload.query)
+
+
+@app.get("/keywords/ideas", response_model=List[KeywordResult])
+def keywords_ideas(query: str, region: str | None = None) -> List[KeywordResult]:
+    return services.keyword_ideas(query, region)
+
+
+@app.get("/serp/top")
+def serp_top(keyword: str, date: str | None = None) -> dict:
+    return services.serp_top(keyword, date)
+
+
+@app.post("/domain/compare")
+def domain_compare(payload: DomainCompareRequest) -> dict:
+    return services.compare_domains(payload.primary_domain, payload.competitor_domains)
+
+
+@app.post("/audit/start", status_code=202)
+def audit_start(payload: AuditStartRequest) -> dict:
+    return services.start_audit(payload.domain)
+
+
+@app.get("/audit/report/{audit_id}")
+def audit_report(audit_id: str) -> dict:
+    report = services.get_audit_report(audit_id)
+    if not report:
+        raise HTTPException(status_code=404, detail="Audit hittades inte")
+    return report
+
+
+@app.get("/backlinks/summary")
+def backlinks_summary(domain: str) -> dict:
+    return services.backlinks_summary(domain)
+
+
+@app.post("/content/brief")
+def content_brief(payload: ContentBriefRequest) -> dict:
+    return services.generate_content_brief(
+        keyword=payload.keyword,
+        competitors=payload.competitors,
+        tone=payload.tone,
+        cta_type=payload.cta_type,
+    )
+
+
+@app.get("/local/keywords", response_model=List[KeywordResult])
+def local_keywords(region: str, query: str | None = None) -> List[KeywordResult]:
+    return services.local_keywords(region, query)
+
+
+@app.get("/projects")
+def list_projects() -> list[dict]:
+    return services.list_projects()
+
+
+@app.post("/projects")
+def create_project(project: dict) -> dict:
+    return services.create_project(project)
+

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -1,0 +1,266 @@
+"""Mockade datatjänster för MVP."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from . import utils
+
+PROJECTS = [
+    {
+        "id": "proj-1",
+        "name": "Hälsokost Sverige",
+        "industry": "Kosttillskott",
+        "target_region": "Sverige",
+        "created_at": "2024-01-04T10:00:00Z",
+    }
+]
+
+KEYWORD_DATA = {
+    "ashwagandha gummies": {
+        "search_volume": 1900,
+        "kd_se": utils.calculate_kd_se(52, 47, 55),
+        "cpc_sek": 14.5,
+        "trend": [1500, 1600, 1700, 1750, 1800, 1850, 1900, 2000, 2050, 2100, 2150, 2200],
+        "serp_features": ["Shopping", "Video", "People also ask"],
+    },
+    "vitamin c gummis": {
+        "search_volume": 1300,
+        "kd_se": utils.calculate_kd_se(46, 40, 42),
+        "cpc_sek": 9.8,
+        "trend": [900, 950, 970, 1000, 1020, 1080, 1150, 1200, 1250, 1300, 1320, 1350],
+        "serp_features": ["Shopping", "Recensioner"],
+    },
+    "kollagen tillskott": {
+        "search_volume": 4400,
+        "kd_se": utils.calculate_kd_se(60, 58, 62),
+        "cpc_sek": 21.3,
+        "trend": [3800, 3900, 3950, 4000, 4100, 4200, 4300, 4350, 4400, 4500, 4600, 4700],
+        "serp_features": ["Top stories", "People also ask"],
+    },
+    "sea moss kapslar": {
+        "search_volume": 880,
+        "kd_se": utils.calculate_kd_se(40, 32, 38),
+        "cpc_sek": 13.7,
+        "trend": [500, 520, 540, 560, 600, 620, 650, 700, 750, 800, 850, 880],
+        "serp_features": ["Shopping"],
+    },
+    "probiotika barn": {
+        "search_volume": 2400,
+        "kd_se": utils.calculate_kd_se(48, 44, 50),
+        "cpc_sek": 16.0,
+        "trend": [2000, 2050, 2100, 2120, 2150, 2200, 2250, 2300, 2350, 2380, 2400, 2450],
+        "serp_features": ["People also ask", "Video"],
+    },
+}
+
+SERP_DATA = {
+    "ashwagandha gummies": {
+        "collected_at": "2024-04-10",
+        "top_domains": [
+            {"domain": "apoteket.se", "url": "https://www.apoteket.se/ashwagandha-gummies", "position": 1},
+            {"domain": "kostdoktorn.se", "url": "https://www.kostdoktorn.se/ashwagandha", "position": 2},
+            {"domain": "scandicwellness.se", "url": "https://www.scandicwellness.se/ashwagandha-gummies", "position": 3},
+        ],
+        "serp_diff": "Stabila topp-3, ny video-snutt från YouTube",
+    }
+}
+
+AUDIT_REPORTS = {
+    "audit-scandicwellness": {
+        "domain": "scandicwellness.se",
+        "status": "klar",
+        "completed_at": "2024-04-11T09:30:00Z",
+        "issues": [
+            {
+                "title": "Saknad H1 på /produkter/ashwagandha",
+                "impact_score": 0.6,
+                "effort_score": 0.3,
+                "probability": 0.8,
+                "priority": utils.calculate_priority(0.6, 0.8, 0.3),
+            },
+            {
+                "title": "Långsam LCP på startsida",
+                "impact_score": 0.7,
+                "effort_score": 0.5,
+                "probability": 0.7,
+                "priority": utils.calculate_priority(0.7, 0.7, 0.5),
+            },
+        ],
+        "core_web_vitals": {
+            "lcp": 3.1,
+            "fid": 75,
+            "cls": 0.11,
+        },
+        "summary": "Fokusera på rubriker och CWV-optimering för produktkategorier.",
+    }
+}
+
+BACKLINKS = {
+    "scandicwellness.se": {
+        "total_domains": 45,
+        "dofollow": 120,
+        "nofollow": 30,
+        "tox_score": utils.calculate_tox_score("ASHWAGANDHA", ".xyz", 32, 3),
+        "top_anchors": [
+            {"anchor": "ashwagandha gummies", "count": 35},
+            {"anchor": "scandic wellness", "count": 22},
+        ],
+        "new_links": 5,
+        "lost_links": 2,
+    }
+}
+
+LOCAL_KEYWORDS = {
+    "stockholm": [
+        {"keyword": "ashwagandha butik stockholm", "search_volume": 150, "kd_se": 36, "cpc_sek": 12.5,
+         "trend": [90, 95, 100, 110, 120, 130, 135, 140, 145, 150, 152, 155], "serp_features": ["Maps"]},
+        {"keyword": "hälsokost odenplan", "search_volume": 210, "kd_se": 42, "cpc_sek": 9.7,
+         "trend": [180, 182, 185, 188, 190, 195, 198, 200, 202, 205, 208, 210], "serp_features": ["Local pack"]},
+    ],
+    "göteborg": [
+        {"keyword": "probiotika barn göteborg", "search_volume": 120, "kd_se": 44, "cpc_sek": 10.1,
+         "trend": [80, 85, 90, 93, 96, 100, 105, 110, 112, 115, 118, 120], "serp_features": ["Local pack"]}
+    ],
+    "malmö": [
+        {"keyword": "vitamin c gummis malmö", "search_volume": 90, "kd_se": 38, "cpc_sek": 11.2,
+         "trend": [60, 62, 65, 68, 70, 75, 78, 80, 82, 85, 88, 90], "serp_features": ["Maps"]}
+    ],
+}
+
+
+def search_keywords(query: str) -> List[dict]:
+    results = []
+    for keyword, data in KEYWORD_DATA.items():
+        if query.lower() in keyword.lower():
+            results.append({"keyword": keyword, **data})
+    if not results:
+        return [
+            {"keyword": query, "search_volume": 0, "kd_se": 0.0, "cpc_sek": 0.0, "trend": [], "serp_features": []}
+        ]
+    return results
+
+
+def keyword_ideas(query: str, region: str | None) -> List[dict]:
+    base = search_keywords(query)
+    ideas = []
+    for item in base:
+        ideas.append(item)
+        ideas.append(
+            {
+                "keyword": f"{item['keyword']} guide",
+                "search_volume": int(item["search_volume"] * 0.4),
+                "kd_se": round(item["kd_se"] * 0.8, 2),
+                "cpc_sek": round(item["cpc_sek"] * 0.7, 2),
+                "trend": item["trend"][-6:],
+                "serp_features": ["People also ask"],
+            }
+        )
+    if region:
+        for local in LOCAL_KEYWORDS.get(region.lower(), []):
+            if query.lower() in local["keyword"]:
+                ideas.append(local)
+    return ideas[:6]
+
+
+def serp_top(keyword: str, date: str | None) -> dict:
+    serp = SERP_DATA.get(keyword)
+    if not serp:
+        return {"keyword": keyword, "top_domains": [], "collected_at": date or datetime.utcnow().date().isoformat()}
+    return serp
+
+
+def compare_domains(primary: str, competitors: List[str]) -> dict:
+    sample_positions = [
+        (1, 2400),
+        (4, 1300),
+        (7, 880),
+    ]
+    visibility = utils.calculate_visibility(sample_positions)
+    competitor_overview = []
+    for competitor in competitors:
+        competitor_overview.append(
+            {
+                "domain": competitor,
+                "shared_keywords": 120,
+                "missed_keywords": 80,
+                "estimated_traffic": 18000,
+            }
+        )
+    return {
+        "primary_domain": primary,
+        "visibility_index": visibility,
+        "competitors": competitor_overview,
+    }
+
+
+def start_audit(domain: str) -> dict:
+    audit_id = f"audit-{domain.replace('.', '-') }"
+    AUDIT_REPORTS.setdefault(
+        audit_id,
+        {
+            "domain": domain,
+            "status": "pågår",
+            "started_at": datetime.utcnow().isoformat() + "Z",
+            "issues": [],
+            "summary": "Audit startad med mockade data",
+        },
+    )
+    return {"audit_id": audit_id, "status": "pågår"}
+
+
+def get_audit_report(audit_id: str) -> dict | None:
+    return AUDIT_REPORTS.get(audit_id)
+
+
+def backlinks_summary(domain: str) -> dict:
+    return BACKLINKS.get(
+        domain,
+        {
+            "total_domains": 0,
+            "dofollow": 0,
+            "nofollow": 0,
+            "tox_score": 0,
+            "top_anchors": [],
+            "new_links": 0,
+            "lost_links": 0,
+        },
+    )
+
+
+def generate_content_brief(keyword: str, competitors: List[str], tone: str, cta_type: str) -> dict:
+    outline = [
+        {"heading": "H1", "text": f"Allt du behöver veta om {keyword}"},
+        {"heading": "H2", "text": "Fördelar och vetenskap"},
+        {"heading": "H2", "text": "Dosering och säkerhet"},
+        {"heading": "H3", "text": "Vanliga frågor från svenska kunder"},
+    ]
+    entities = ["ashwagandha", "adaptogener", "stress", "sömn"] if "ashwagandha" in keyword else ["vitamin C", "immunförsvar"]
+    return {
+        "keyword": keyword,
+        "tone": tone,
+        "cta": cta_type,
+        "competitors": competitors,
+        "outline": outline,
+        "recommended_entities": entities,
+        "meta_description": f"Lär dig mer om {keyword} och hur svenska varumärken positionerar sig.",
+    }
+
+
+def local_keywords(region: str, query: str | None) -> List[dict]:
+    items = LOCAL_KEYWORDS.get(region.lower(), [])
+    if query:
+        return [item for item in items if query.lower() in item["keyword"]]
+    return items
+
+
+def list_projects() -> List[dict]:
+    return PROJECTS
+
+
+def create_project(project: dict) -> dict:
+    project["id"] = project.get("id", f"proj-{len(PROJECTS) + 1}")
+    project.setdefault("created_at", datetime.utcnow().isoformat() + "Z")
+    PROJECTS.append(project)
+    return project
+

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,30 @@
+"""Gemensamma beräkningsfunktioner."""
+from __future__ import annotations
+
+
+def calculate_kd_se(mean_domain_authority: float, backlink_strength: float, serp_volume_weight: float) -> float:
+    kd = (mean_domain_authority + backlink_strength + serp_volume_weight) / 3
+    return round(min(max(kd, 0), 100), 2)
+
+
+def calculate_visibility(positions: list[tuple[int, int]]) -> float:
+    weights = {1: 1.0, 2: 0.8, 3: 0.6, 4: 0.5, 5: 0.4, 6: 0.35, 7: 0.3, 8: 0.25, 9: 0.2, 10: 0.15}
+    numerator = sum(weights.get(pos, 0.1) * volume for pos, volume in positions)
+    denominator = sum(volume for _, volume in positions) or 1
+    return round(numerator / denominator, 3)
+
+
+def calculate_priority(traffic_impact: float, success_probability: float, effort: float) -> float:
+    if effort == 0:
+        return round(traffic_impact * success_probability * 1.5, 2)
+    return round((traffic_impact * success_probability) / effort, 2)
+
+
+def calculate_tox_score(anchor_text: str, tld: str, domain_trust: float, spam_signals: int) -> float:
+    risky_anchor = 20 if anchor_text.isupper() or "gratis" in anchor_text.lower() else 0
+    tld_penalty = 15 if tld in {".xyz", ".info"} else 0
+    trust_penalty = max(0, 50 - domain_trust)
+    spam_penalty = spam_signals * 5
+    score = min(100, risky_anchor + tld_penalty + trust_penalty + spam_penalty)
+    return round(score, 1)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.6.4
+pytest==8.1.1
+httpx==0.27.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_keywords_search_returns_result():
+    response = client.post("/keywords/search", json={"query": "ashwagandha"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data
+    assert data[0]["keyword"].startswith("ashwagandha")
+    assert "kd_se" in data[0]
+
+
+def test_audit_lifecycle():
+    start = client.post("/audit/start", json={"domain": "scandicwellness.se"})
+    assert start.status_code == 202
+    audit_id = start.json()["audit_id"]
+
+    report = client.get(f"/audit/report/{audit_id}")
+    assert report.status_code == 200
+    issues = report.json().get("issues")
+    assert isinstance(issues, list)
+
+
+def test_content_brief_generation():
+    response = client.post(
+        "/content/brief",
+        json={
+            "keyword": "ashwagandha gummies",
+            "competitors": ["apoteket.se"],
+            "tone": "Varm och rådgivande",
+            "cta_type": "Köp nu",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["keyword"] == "ashwagandha gummies"
+    assert "outline" in body
+
+

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -1,0 +1,59 @@
+# Algoritmer & Beräkningslogik
+
+## Keyword Difficulty (KD_SE)
+```python
+def calculate_kd_se(mean_domain_authority: float, backlink_strength: float, serp_volume_weight: float) -> float:
+    """Beräknar svensk keyword difficulty genom att normalisera på 0-100."""
+    kd = (mean_domain_authority + backlink_strength + serp_volume_weight) / 3
+    return round(min(max(kd, 0), 100), 2)
+```
+- **mean_domain_authority:** Genomsnittligt DA för topp-10-resultat (skalat 0-100).
+- **backlink_strength:** Normaliserad länkstyrka baserad på referring domains och relevans.
+- **serp_volume_weight:** Viktning av SERP-variabilitet (antal features, historiska hopp).
+
+## Synlighetsindex (SE)
+```python
+def calculate_visibility(positions: list[tuple[int, int]]) -> float:
+    """positions: lista av (position, volym)."""
+    weights = {1: 1.0, 2: 0.8, 3: 0.6, 4: 0.5, 5: 0.4, 6: 0.35, 7: 0.3, 8: 0.25, 9: 0.2, 10: 0.15}
+    numerator = sum(weights.get(pos, 0.1) * volume for pos, volume in positions)
+    denominator = sum(volume for _, volume in positions) or 1
+    return round(numerator / denominator, 3)
+```
+
+## Audit Prioritet
+```python
+def calculate_priority(traffic_impact: float, success_probability: float, effort: float) -> float:
+    if effort == 0:
+        return traffic_impact * success_probability * 1.5
+    return round((traffic_impact * success_probability) / effort, 2)
+```
+- **traffic_impact:** Procentuellt estimat av trafikförlust/vinst (0-1).
+- **success_probability:** Sannolikhet att åtgärden lyckas (0-1).
+- **effort:** Relativ arbetsinsats (1 = 1 dag).
+
+## Tox-score
+```python
+def calculate_tox_score(anchor_text: str, tld: str, domain_trust: float, spam_signals: int) -> float:
+    risky_anchor = 20 if anchor_text.isupper() or "gratis" in anchor_text.lower() else 0
+    tld_penalty = 15 if tld in {".xyz", ".info"} else 0
+    trust_penalty = max(0, 50 - domain_trust)
+    spam_penalty = spam_signals * 5
+    score = min(100, risky_anchor + tld_penalty + trust_penalty + spam_penalty)
+    return round(score, 1)
+```
+
+## AI Keyword Clustering (V2)
+- Normalisera sökord via svensk stemming och lemmatisering.
+- Beräkna TF-IDF-matris och reducera med PCA → K-means.
+- Använd silhouette score för att välja optimalt antal kluster.
+
+## AI Content Optimization Engine (V2)
+- Bygger feature-matris med entiteter, läsbarhetsindex (LIX), sentiment och SERP-coverage.
+- Beräkna score = viktad summa mot top-3 i SERP.
+- Återkoppla rekommendationer (saknade entiteter, rubrikstruktur).
+
+## Auto SEO Insights (V2)
+- Cron-jobb analyserar `serp_snapshots` och Google Search Console-data.
+- Trigger notifiering vid >15% tapp i synlighet eller stor positionsförändring.
+

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,24 @@
+# Backlog & Framtida Expansion
+
+## V2-funktioner
+1. **Länkdatabas** – Bygg egen datalake med svensk crawling, uppdateras dagligen.
+2. **Rank tracking per dag** – Schemalagda SERP-snapshots och alerting.
+3. **Google Sheets-export** – Push av rapporter via Google API.
+4. **White-label-rapportering** – Anpassade teman och logotyper per kund.
+5. **Chrome Extension** – Snabb SERP-insikt direkt i webbläsaren.
+6. **Teamdelning** – Roller på projektnivå, gästlänkar.
+
+## AI-expansion
+- AI Keyword Clustering (K-means + embeddings).
+- AI Content Optimization Engine (LLM + scoring).
+- Auto SEO Insights (anomalidetektion + notifieringar).
+- AI Crawl Bot (reinforcement learning från audit-resultat).
+
+## Nordisk expansion
+- Lokaliserade datakällor för Norge, Danmark, Finland.
+- Valuta- och språklager per land.
+
+## Integrationer
+- Notion, Shopify, Webflow – webhookdrivna uppdateringar.
+- Zapier-app för automatiserade arbetsflöden.
+

--- a/docs/gdpr_security.md
+++ b/docs/gdpr_security.md
@@ -1,0 +1,33 @@
+# GDPR & Säkerhetsplan
+
+## Dataminimering
+- Endast nödvändiga personuppgifter lagras: e-post, roll, aktivitetsloggar.
+- Rapporter anonymiserar användare och kunder med projekt-ID.
+- Möjlighet att stänga av loggning av kunddata per projekt.
+
+## Samtycke & rättigheter
+- Onboarding-flöde kräver explicit samtycke för API-integrationer.
+- "Radera mig"-funktion tar bort användarkonto, anonymiserar projektägare och raderar tokens.
+- Export av personuppgifter via `/users/me/export` (v2).
+
+## Åtkomst & roller
+- RBAC: Admin kan hantera organisation och fakturering. Användare ser egna projekt. Gäst får läsrättigheter.
+- Auditloggar för inloggningar, exports, rapportgenerering.
+
+## Säkerhetsåtgärder
+- HTTPS överallt, HSTS och säkra cookies för frontend.
+- JWT med 60 min utgång + refresh tokens. Tokens lagras inte i LocalStorage utan i httpOnly cookies.
+- Secret rotation via Vault/GitHub Actions hemligheter.
+- Rate limiting per användare/IP, skydd mot brute force.
+- Crawler följer robots.txt och respekterar crawl-delay.
+
+## Databehandling & retention
+- Projektdata lagras 24 månader, därefter arkiveras eller anonymiseras.
+- Backups krypterade (AES-256) och roterade veckovis.
+- Loggar sparas 12 månader för revision.
+
+## Incidentrespons
+1. Detektion via monitorering och larm.
+2. Incident-team aktiveras, RCA inom 48h.
+3. Rapportering till IMY och drabbade kunder inom 72h.
+

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,56 @@
+# Produktkravsdokument (PRD) – Svensk SEO-plattform
+
+## Översikt
+Den svenska SEO-plattformen riktar sig till e-handlare, byråer och tillväxtbolag som behöver ett lokalt anpassat alternativ till Semrush. Fokus för MVP är kärnflödena sökordsanalys, konkurrensinsikter, teknisk audit, länkprofil och AI-stödd innehållsplanering med mockade datakällor. Systemet ska vara utbyggbart för verkliga integrationer i senare versioner.
+
+## Mål & KPI:er
+- **Primär KPI:** Antal aktiva projekt (mål: 50 under första kvartalet efter lansering).
+- **Sekundära KPI:er:**
+  - Exporterade rapporter per månad (mål: 150).
+  - Genomsnittlig tid till första audit (mål: < 5 minuter).
+  - Nöjdhetsbetyg för AI-briefar (mål: ≥ 4/5).
+
+## Målgruppsproblem
+- Svårt att hitta svensk volym- och CPC-data.
+- Brist på lokalt anpassad konkurrensanalys.
+- Fragmenterade verktyg för tekniska insikter och innehållsplanering.
+- Svårt att arbeta GDPR-säkert med flera kundprojekt.
+
+## MVP-omfång
+1. **Projekt & domäner** – skapa, tilldela och kategorisera.
+2. **Sökordssökning** – volym, KD_SE, CPC i SEK, trend, SERP-features och relaterade sökord.
+3. **Konkurrentanalys** – toppdomäner/URL:er, domänjämförelse, SERP-diff.
+4. **Site Audit** – starta audit, få prioriterad åtgärdslista.
+5. **Backlinks** – summera länkprofil och tox-score.
+6. **AI-innehållsbrief** – generera svensk brief med rubrikstruktur och CTA.
+7. **Lokal SEO** – kommun/län-filter, "nära mig"-varianter och NAP-kontroller.
+8. **Export** – CSV och PDF (genereras i MVP som markdown + instruktion för PDF).
+9. **Autentisering & roller** – JWT-baserad inloggning, roller Admin/Användare/Gäst.
+
+## V2+ funktioner
+- Riktig länkdatabas, daglig rank tracking, Google Sheets-export, white-labeling, Chrome-extension, teamdelning.
+
+## Antaganden & risker
+- API-licenser för sökdata måste förhandlas (Semrush, Ahrefs-alternativ eller egen datapartnerskap).
+- Crawling får inte bryta mot robots.txt eller lagar.
+- AI-genererade briefs måste kvalitetssäkras för tonläge och korrekthet.
+
+## User Stories (MVP)
+- **Som SEO-specialist** vill jag lägga till ett nytt projekt för min kund och spåra deras domänstatus.
+- **Som innehållsstrateg** vill jag hitta svenska long-tail-sökord med låg KD_SE för att producera innehåll.
+- **Som teknisk konsult** vill jag köra en site audit och få en prioriterad lista över problem.
+- **Som byråledare** vill jag exportera rapporter i CSV/PDF för att visa värde för kunder.
+- **Som lokal marknadsförare** vill jag identifiera "nära mig"-sökord per kommun.
+
+## Icke-funktionella krav
+- UI på svenska, tider och datum i svensk zon.
+- Responstider < 500 ms för cacheade endpointar.
+- Skalbar backend (containeriserad) med observability-basnivå.
+- GDPR-efterlevnad: dataminimering, rätt att bli raderad, aktivitetlogg.
+
+## Milstolpar
+1. **Vecka 1-2:** Arkitektur, datamodell, mock-API.
+2. **Vecka 3:** Frontend UI, rapportmallar.
+3. **Vecka 4:** Tester, CI, dokumentation.
+4. **Vecka 5:** Beta-feedback från 5 pilotkunder.
+

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -1,0 +1,239 @@
+# Systemdesign & Arkitektur
+
+## Arkitekturöversikt
+```mermaid
+graph TD
+    subgraph Klient
+        UI[Next.js UI (svenska)]
+    end
+    subgraph API
+        GW[FastAPI REST]
+        MQ[Redis Queue]
+        Worker[Celery Workers]
+    end
+    subgraph Data
+        PG[(PostgreSQL)]
+        Cache[Redis Cache]
+        Storage[(Object Storage - rapporter)]
+    end
+    subgraph Integrations
+        GSC[Google Search Console]
+        GAds[Google Ads]
+        GAnalytics[Google Analytics]
+    end
+
+    UI -->|JWT| GW
+    GW --> PG
+    GW --> Cache
+    GW --> MQ
+    MQ --> Worker
+    Worker --> PG
+    Worker --> Storage
+    Worker -->|Adapter| GSC
+    Worker --> GAds
+    Worker --> GAnalytics
+```
+
+## Modulöversikt
+- **Autentisering:** JWT och OAuth2. Roller: Admin, Användare, Gäst.
+- **Keyword Service:** Hämtar från licensierade API:er, normaliserar till `keywords`-tabell.
+- **SERP Service:** Schemalagd hämtning via Playwright crawler och API, lagras i `serp_snapshots`.
+- **Audit Service:** Crawlar via Celery worker. Prioritetsberäkning på backend.
+- **Backlink Service:** Import från extern leverantör, beräkning av tox-score.
+- **AI Content Service:** Promptar LLM (svenskt språk) via AI-provider.
+- **Lokal SEO Service:** Kombinerar sökdata med SCB-geodata.
+
+## Datamodell (PostgreSQL)
+```sql
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    hashed_password TEXT NOT NULL,
+    role TEXT CHECK (role IN ('admin','user','guest')) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE projects (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id),
+    name TEXT NOT NULL,
+    industry TEXT,
+    target_region TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE domains (
+    id UUID PRIMARY KEY,
+    project_id UUID REFERENCES projects(id),
+    domain_name TEXT NOT NULL,
+    visibility_index NUMERIC,
+    last_audit_id UUID,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE keywords (
+    id UUID PRIMARY KEY,
+    project_id UUID REFERENCES projects(id),
+    keyword TEXT NOT NULL,
+    search_volume INT,
+    kd_se NUMERIC,
+    cpc_sek NUMERIC,
+    trend JSONB,
+    serp_features TEXT[],
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE serp_snapshots (
+    id UUID PRIMARY KEY,
+    keyword_id UUID REFERENCES keywords(id),
+    collected_at DATE NOT NULL,
+    top_results JSONB,
+    visibility_score NUMERIC
+);
+
+CREATE TABLE audits (
+    id UUID PRIMARY KEY,
+    domain_id UUID REFERENCES domains(id),
+    status TEXT,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    summary JSONB
+);
+
+CREATE TABLE issues (
+    id UUID PRIMARY KEY,
+    audit_id UUID REFERENCES audits(id),
+    title TEXT,
+    impact_score NUMERIC,
+    effort_score NUMERIC,
+    probability NUMERIC,
+    priority NUMERIC,
+    status TEXT
+);
+
+CREATE TABLE backlinks (
+    id UUID PRIMARY KEY,
+    domain_id UUID REFERENCES domains(id),
+    source_domain TEXT,
+    target_url TEXT,
+    anchor_text TEXT,
+    rel TEXT,
+    tox_score NUMERIC,
+    discovered_at DATE,
+    lost_at DATE
+);
+
+CREATE TABLE briefs (
+    id UUID PRIMARY KEY,
+    project_id UUID REFERENCES projects(id),
+    keyword TEXT,
+    outline JSONB,
+    tone TEXT,
+    cta TEXT,
+    suggested_entities TEXT[],
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE connections (
+    id UUID PRIMARY KEY,
+    project_id UUID REFERENCES projects(id),
+    provider TEXT,
+    refresh_token TEXT,
+    scopes TEXT[],
+    consented_at TIMESTAMPTZ
+);
+```
+
+## OpenAPI-utdrag
+```yaml
+openapi: 3.1.0
+info:
+  title: Svensk SEO-plattform API
+  version: 0.1.0
+paths:
+  /keywords/search:
+    post:
+      summary: Sökordssökning på Google.se
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                project_id:
+                  type: string
+      responses:
+        "200":
+          description: Lista med sökordsdata
+  /keywords/ideas:
+    get:
+      summary: Relaterade sökordsidéer
+      parameters:
+        - in: query
+          name: query
+          schema:
+            type: string
+        - in: query
+          name: region
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Idéer med long-tail och böjningar
+  /serp/top:
+    get:
+      summary: Toppdomäner & URL:er
+      parameters:
+        - in: query
+          name: keyword
+          schema:
+            type: string
+        - in: query
+          name: date
+          schema:
+            type: string
+      responses:
+        "200":
+          description: SERP-resultat
+  /domain/compare:
+    post:
+      summary: Domän mot domän jämförelse
+      responses:
+        "200":
+          description: Trafikestimat och synlighetsindex
+  /audit/start:
+    post:
+      summary: Starta site audit
+      responses:
+        "202":
+          description: Audit initierad
+  /audit/report/{id}:
+    get:
+      summary: Hämta auditrapport
+      responses:
+        "200":
+          description: Auditresultat
+  /backlinks/summary:
+    get:
+      summary: Länkprofil och tox-score
+  /content/brief:
+    post:
+      summary: Generera svensk innehållsbrief
+  /local/keywords:
+    get:
+      summary: Lokala sökord per region/kommun
+```
+
+## Säkerhetskomponenter
+- JWT-signering med `HS256` och roterande hemligheter.
+- OAuth2 authorization code-flow för externa integrationer.
+- Logging via strukturerad JSON till ELK/OpenSearch.
+- Rate limiting via Redis-token bucket.
+
+## Driftsättning
+- Docker-compose för lokalt, Kubernetes/Railway för backend, Vercel för frontend.
+- Celery workers som separata pods/containers.
+- Nightly schemalagda jobb för SERP-diff och backlink-refresh.
+

--- a/docs/testplan_ci.md
+++ b/docs/testplan_ci.md
@@ -1,0 +1,31 @@
+# Testplan & CI
+
+## Enhetstester
+- Python: pytest för beräkningsfunktioner och API-svar (mock-data).
+- Frontend: Jest/React Testing Library (placeholder i MVP med snapshot-test av komponent).
+
+## Integrationstester
+- Använd FastAPI TestClient för att testa hela flöden (t.ex. starta audit och hämta rapport).
+- Simulera domänjämförelse med flera domäner.
+
+## CI-pipeline (GitHub Actions)
+1. `lint-python`: kör `ruff` (v2 plan) eller `flake8` (MVP skip, se TODO).
+2. `test-python`: installerar beroenden och kör pytest.
+3. `test-frontend`: installerar npm, kör `npm run test`.
+4. `build`: validerar Dockerfile (v2).
+
+## Testdata
+- Sökord: “ashwagandha gummies”, “vitamin c gummis”, “kollagen tillskott”, “sea moss kapslar”, “probiotika barn”.
+- Domäner: scandicwellness.se, apoteket.se, kostdoktorn.se.
+- Regioner: Stockholm, Göteborg, Malmö.
+
+## Manuell QA-checklista
+- Bekräfta att UI byter språk till svenska (default).
+- Testa CSV-export från sökordsflik.
+- Trigger audit och kontrollera prioriterad lista.
+- Generera innehållsbrief och kontrollera att CTA är på svenska.
+
+## Deployment-validering
+- Pre-prod (Railway) röktest: hälsoendpoint `/health` svarar 200.
+- Frontend (Vercel) – kontrollera att Next.js-sidor laddas och API-basen pekar rätt.
+

--- a/docs/ux_ui.md
+++ b/docs/ux_ui.md
@@ -1,0 +1,62 @@
+# UX/UI-Skiss & Komponenter
+
+## Navigationsstruktur
+1. Projektöversikt
+2. Sökordsforskning
+3. Konkurrenter & SERP
+4. Site Audit
+5. Backlinks
+6. Innehållsplanering
+7. Lokal SEO
+
+## Designprinciper
+- UI på svenska, typsnitt Inter, färgpalett inspirerad av nordiskt ljus (blå, vit, accent orange).
+- Alla monetära värden visas i SEK med två decimaler.
+- Tillgänglighet: WCAG AA, tydliga kontraster, ARIA-etiketter.
+
+## Layoutskiss (textuell)
+```
+-------------------------------------------------
+| Logo | Projektväljare | + Lägg till projekt  ⚙ |
+-------------------------------------------------
+| Sidomeny              | Innehållsområde        |
+| 1. Projektöversikt    | Huvudkort: KPI         |
+| 2. Sökordsforskning   | Diagram: Trend         |
+| ...                   | Tabell: Sökord         |
+-------------------------------------------------
+```
+
+## Komponentexempel – Trendgraf (React + Recharts)
+```tsx
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface TrendGrafProps {
+  data: { manad: string; volym: number }[];
+}
+
+export const TrendGraf: React.FC<TrendGrafProps> = ({ data }) => (
+  <div className="bg-white rounded-lg shadow p-4">
+    <h3 className="text-lg font-semibold mb-2">12 månaders trend</h3>
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="manad" tick={{ fontSize: 12 }} />
+        <YAxis tickFormatter={(value) => `${value.toLocaleString('sv-SE')}`}/>
+        <Tooltip formatter={(value: number) => `${value.toLocaleString('sv-SE')} sökningar`} />
+        <Line type="monotone" dataKey="volym" stroke="#2563eb" strokeWidth={3} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  </div>
+);
+```
+
+## Interaktionsflöden
+- **Sökordsforskning:** Ange sökord → visa huvudkort med volym, KD_SE, CPC, trenddiagram och tabell med relaterade sökord.
+- **Audit:** Klicka “Starta audit” → modal med bekräftelse → statuskort i realtid → färdig rapport i tabell.
+- **Innehållsbrief:** Välj konkurrenter + CTA-typ → genererar brief i panel med exportknappar.
+- **Lokal SEO:** Sök stad → filtrerad lista med lokala sökord och NAP-status.
+
+## Exportkomponenter
+- `ExportKnapp` erbjuder CSV eller PDF (via serverrenderad markdown till PDF).
+- Download feedback via toast på svenska: “Export klar – filen laddades ned.”
+

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import HomePage from '../pages/index';
+
+describe('HomePage', () => {
+  it('visar svenska rubriker', () => {
+    render(<HomePage />);
+    expect(screen.getByText('Svensk SEO-plattform')).toBeInTheDocument();
+    expect(screen.getByText('Projektöversikt')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/KeywordTable.tsx
+++ b/frontend/components/KeywordTable.tsx
@@ -1,0 +1,61 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface KeywordRow {
+  keyword: string;
+  search_volume: number;
+  kd_se: number;
+  cpc_sek: number;
+  trend: number[];
+  serp_features: string[];
+}
+
+interface KeywordTableProps {
+  query: string;
+}
+
+export function KeywordTable({ query }: KeywordTableProps) {
+  const { data } = useSWR<KeywordRow[]>(
+    query ? `http://localhost:8000/keywords/search` : null,
+    (url) =>
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      }).then((res) => res.json())
+  );
+
+  if (!query) {
+    return <p>Ange ett sökord för att se resultat.</p>;
+  }
+
+  if (!data) {
+    return <p>Laddar...</p>;
+  }
+
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <th>Sökord</th>
+          <th>Volym</th>
+          <th>KD_SE</th>
+          <th>CPC (SEK)</th>
+          <th>SERP-features</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row) => (
+          <tr key={row.keyword}>
+            <td>{row.keyword}</td>
+            <td>{row.search_volume.toLocaleString('sv-SE')}</td>
+            <td>{row.kd_se}</td>
+            <td>{row.cpc_sek.toFixed(2)}</td>
+            <td>{row.serp_features.join(', ')}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/components/TrendGraf.tsx
+++ b/frontend/components/TrendGraf.tsx
@@ -1,0 +1,22 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface TrendGrafProps {
+  data: { manad: string; volym: number }[];
+}
+
+export function TrendGraf({ data }: TrendGrafProps) {
+  return (
+    <div className="card">
+      <h3 style={{ marginTop: 0 }}>12 månaders trend</h3>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="manad" />
+          <YAxis />
+          <Tooltip formatter={(value: number) => `${value.toLocaleString('sv-SE')} sökningar`} />
+          <Line type="monotone" dataKey="volym" stroke="#2563eb" strokeWidth={3} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './'
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jsdom'
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "seo-plattform-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.0",
+    "recharts": "2.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.41",
+    "@types/react-dom": "18.2.17",
+    "typescript": "5.3.3",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.1.6"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/audit.tsx
+++ b/frontend/pages/audit.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+interface AuditIssue {
+  title: string;
+  priority: number;
+}
+
+export default function AuditPage() {
+  const [domain, setDomain] = useState('scandicwellness.se');
+  const [report, setReport] = useState<any>(null);
+
+  async function handleAudit() {
+    const start = await fetch('http://localhost:8000/audit/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain })
+    }).then((res) => res.json());
+
+    const response = await fetch(`http://localhost:8000/audit/report/${start.audit_id}`);
+    setReport(await response.json());
+  }
+
+  return (
+    <main>
+      <h1>Site Audit</h1>
+      <p>Crawla din svenska domän och få en prioriterad åtgärdslista.</p>
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <label htmlFor="domain" style={{ display: 'block', marginBottom: '0.5rem' }}>
+          Domän
+        </label>
+        <input
+          id="domain"
+          value={domain}
+          onChange={(event) => setDomain(event.target.value)}
+          style={{ padding: '0.75rem', width: '100%', borderRadius: '0.75rem', border: '1px solid #d1d5db' }}
+          placeholder="Ex. scandicwellness.se"
+        />
+        <button className="button" style={{ marginTop: '1rem' }} onClick={handleAudit}>
+          Starta audit
+        </button>
+      </div>
+      {report && (
+        <section className="card">
+          <h2>Prioriterad lista</h2>
+          <ol>
+            {report.issues?.map((issue: AuditIssue) => (
+              <li key={issue.title}>
+                {issue.title} – Prioritet {issue.priority}
+              </li>
+            ))}
+          </ol>
+          <p>{report.summary}</p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/pages/content.tsx
+++ b/frontend/pages/content.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+interface ContentBrief {
+  outline: { heading: string; text: string }[];
+  meta_description: string;
+  recommended_entities: string[];
+  tone: string;
+  cta: string;
+}
+
+export default function ContentPage() {
+  const [keyword, setKeyword] = useState('ashwagandha gummies');
+  const [brief, setBrief] = useState<ContentBrief | null>(null);
+
+  async function generateBrief() {
+    const response = await fetch('http://localhost:8000/content/brief', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ keyword, competitors: ['apoteket.se'], tone: 'Varm och rådgivande', cta_type: 'Köp nu' })
+    });
+    setBrief(await response.json());
+  }
+
+  return (
+    <main>
+      <h1>Innehållsplanering</h1>
+      <p>Skapa AI-genererade briefar med svensk tonalitet, entiteter och CTA-förslag.</p>
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <label htmlFor="keyword" style={{ display: 'block', marginBottom: '0.5rem' }}>
+          Fokus-sökord
+        </label>
+        <input
+          id="keyword"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          style={{ padding: '0.75rem', width: '100%', borderRadius: '0.75rem', border: '1px solid #d1d5db' }}
+        />
+        <button className="button" style={{ marginTop: '1rem' }} onClick={generateBrief}>
+          Generera brief
+        </button>
+      </div>
+      {brief && (
+        <section className="card">
+          <h2>AI-brief för {keyword}</h2>
+          <p><strong>Tonalitet:</strong> {brief.tone}</p>
+          <p><strong>CTA:</strong> {brief.cta}</p>
+          <p><strong>Meta-beskrivning:</strong> {brief.meta_description}</p>
+          <h3>Rubriker</h3>
+          <ul>
+            {brief.outline.map((row) => (
+              <li key={`${row.heading}-${row.text}`}>{row.heading}: {row.text}</li>
+            ))}
+          </ul>
+          <h3>Rekommenderade entiteter</h3>
+          <p>{brief.recommended_entities.join(', ')}</p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main>
+      <header className="grid" style={{ gap: '1rem' }}>
+        <h1>Svensk SEO-plattform</h1>
+        <p>
+          Ett Semrush-inspirerat arbetsflöde optimerat för Google.se. Hantera projekt, analysera sökord,
+          konkurrenter och skapa AI-briefar direkt på svenska.
+        </p>
+        <nav className="nav" aria-label="Huvudnavigering">
+          <Link href="/keywords">Sökordsforskning</Link>
+          <Link href="/audit">Site Audit</Link>
+          <Link href="/content">Innehållsplanering</Link>
+          <Link href="/local">Lokal SEO</Link>
+        </nav>
+      </header>
+      <section className="grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
+        <article className="card">
+          <h2>Projektöversikt</h2>
+          <p>Skapa och hantera kundprojekt, koppla domäner och se synlighetsindex över tid.</p>
+        </article>
+        <article className="card">
+          <h2>Konkurrenter &amp; SERP</h2>
+          <p>Jämför domäner, upptäck nya sökord och följ SERP-diff varje vecka.</p>
+        </article>
+        <article className="card">
+          <h2>Backlink-översikt</h2>
+          <p>Visualisera länkprofil, tox-score och generera outreach-listor.</p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/frontend/pages/keywords.tsx
+++ b/frontend/pages/keywords.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { KeywordTable } from '../components/KeywordTable';
+import { TrendGraf } from '../components/TrendGraf';
+
+const trendData = [
+  { manad: 'maj', volym: 1500 },
+  { manad: 'jun', volym: 1600 },
+  { manad: 'jul', volym: 1700 },
+  { manad: 'aug', volym: 1750 },
+  { manad: 'sep', volym: 1800 },
+  { manad: 'okt', volym: 1850 },
+  { manad: 'nov', volym: 1900 },
+  { manad: 'dec', volym: 2000 },
+  { manad: 'jan', volym: 2050 },
+  { manad: 'feb', volym: 2100 },
+  { manad: 'mar', volym: 2150 },
+  { manad: 'apr', volym: 2200 }
+];
+
+export default function KeywordsPage() {
+  const [query, setQuery] = useState('ashwagandha');
+
+  return (
+    <main>
+      <h1>Sökordsforskning</h1>
+      <p>Analysera svenska sökord, long-tail-varianter och SERP-features i realtid.</p>
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <label htmlFor="keyword" style={{ display: 'block', marginBottom: '0.5rem' }}>
+          Sökord
+        </label>
+        <input
+          id="keyword"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          style={{ padding: '0.75rem', width: '100%', borderRadius: '0.75rem', border: '1px solid #d1d5db' }}
+          placeholder="Ex. ashwagandha gummies"
+        />
+      </div>
+      <section className="grid" style={{ gridTemplateColumns: '2fr 1fr' }}>
+        <div className="card">
+          <h2>Resultat</h2>
+          <KeywordTable query={query} />
+        </div>
+        <TrendGraf data={trendData} />
+      </section>
+    </main>
+  );
+}

--- a/frontend/pages/local.tsx
+++ b/frontend/pages/local.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+interface LocalKeyword {
+  keyword: string;
+  search_volume: number;
+  kd_se: number;
+  cpc_sek: number;
+  serp_features: string[];
+}
+
+export default function LocalSeoPage() {
+  const [region, setRegion] = useState('stockholm');
+  const [keywords, setKeywords] = useState<LocalKeyword[]>([]);
+
+  async function fetchLocalKeywords(selectedRegion: string) {
+    const response = await fetch(`http://localhost:8000/local/keywords?region=${selectedRegion}`);
+    const data = await response.json();
+    setKeywords(data);
+  }
+
+  return (
+    <main>
+      <h1>Lokal SEO</h1>
+      <p>Upptäck kommun- och regionbaserade sökord samt NAP-insikter.</p>
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <label htmlFor="region" style={{ display: 'block', marginBottom: '0.5rem' }}>
+          Region
+        </label>
+        <select
+          id="region"
+          value={region}
+          onChange={(event) => {
+            const value = event.target.value;
+            setRegion(value);
+            fetchLocalKeywords(value);
+          }}
+          style={{ padding: '0.75rem', width: '100%', borderRadius: '0.75rem', border: '1px solid #d1d5db' }}
+        >
+          <option value="stockholm">Stockholm</option>
+          <option value="göteborg">Göteborg</option>
+          <option value="malmö">Malmö</option>
+        </select>
+        <button className="button" style={{ marginTop: '1rem' }} onClick={() => fetchLocalKeywords(region)}>
+          Hämta lokala sökord
+        </button>
+      </div>
+      {keywords.length > 0 && (
+        <section className="card">
+          <h2>Sökord för {region}</h2>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Sökord</th>
+                <th>Volym</th>
+                <th>KD_SE</th>
+                <th>CPC (SEK)</th>
+                <th>SERP-features</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keywords.map((item) => (
+                <tr key={item.keyword}>
+                  <td>{item.keyword}</td>
+                  <td>{item.search_volume}</td>
+                  <td>{item.kd_se}</td>
+                  <td>{item.cpc_sek.toFixed(2)}</td>
+                  <td>{item.serp_features.join(', ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,66 @@
+:root {
+  --primary: #2563eb;
+  --accent: #f97316;
+  --bg: #f3f4f6;
+  --text: #1f2937;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+main {
+  padding: 2rem;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.12);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.nav a {
+  font-weight: 600;
+}
+
+.button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/reports/audit_report.md
+++ b/reports/audit_report.md
@@ -1,0 +1,19 @@
+# Site Audit – scandicwellness.se
+
+- **Datum:** 11 april 2024
+- **Status:** Klar
+- **Översikt:** Fokusera på produktkategorier för att förbättra CWV och rubrikstruktur.
+
+## Prioriterad lista (påverkan × sannolikhet / insats)
+1. Saknad H1 på /produkter/ashwagandha – Prioritet 1.6
+2. Långsam LCP på startsida – Prioritet 0.98
+
+## Core Web Vitals
+- LCP: 3.1 s (mål < 2.5 s)
+- FID: 75 ms (grönt)
+- CLS: 0.11 (gult)
+
+## Rekommenderade åtgärder
+- Implementera beskrivande H1 med fokus-sökord och använd svensk semantik.
+- Optimering av hero-bilder, införa lazy loading och modern bildkomprimering.
+- Kontrollera schema.org för produktlistor.

--- a/reports/competitor_gap_report.md
+++ b/reports/competitor_gap_report.md
@@ -1,0 +1,9 @@
+# Konkurrent-gap – ashwagandha gummies
+
+| Domän | Delade sökord | Missade sökord | Synlighetsindex |
+| --- | --- | --- | --- |
+| scandicwellness.se | 130 | 45 | 0.72 |
+| apoteket.se | 180 | 15 | 0.91 |
+| kostdoktorn.se | 95 | 70 | 0.65 |
+
+**Rekommendation:** Förbättra informationsinnehåll om stresshantering och produktrecensioner för att ta mark från apoteket.se.

--- a/reports/keyword_report.md
+++ b/reports/keyword_report.md
@@ -1,0 +1,11 @@
+# Keyword-lista – Hälsokost Sverige (april 2024)
+
+| Sökord | Sökvolym | KD_SE | CPC (SEK) | SERP-features |
+| --- | --- | --- | --- | --- |
+| ashwagandha gummies | 1 900 | 51.33 | 14.50 | Shopping, Video, People also ask |
+| vitamin c gummis | 1 300 | 42.67 | 9.80 | Shopping, Recensioner |
+| kollagen tillskott | 4 400 | 60.00 | 21.30 | Top stories, People also ask |
+| sea moss kapslar | 880 | 36.67 | 13.70 | Shopping |
+| probiotika barn | 2 400 | 47.33 | 16.00 | People also ask, Video |
+
+**Kommentar:** Prioritera long-tail kring ashwagandha för lägre KD och växande trend.

--- a/reports/keyword_report_schema.csv
+++ b/reports/keyword_report_schema.csv
@@ -1,0 +1,7 @@
+column,description,example
+project,Projektnamn,Hälsokost Sverige
+keyword,Sökord,ashwagandha gummies
+search_volume,Sökvolym i Google.se (12 mån snitt),1900
+kd_se,KD_SE enligt plattform,51.33
+cpc_sek,Genomsnittligt CPC i SEK,14.5
+serp_features,Komma-separerade SERP-features,"Shopping;Video;People also ask"


### PR DESCRIPTION
## Summary
- add product requirements, architecture, algorithms, UX and compliance documentation for the Swedish SEO platform
- implement mock FastAPI backend, example Next.js frontend, and sample SEO reports to cover MVP flows
- configure automated testing pipeline and repository ignores for local tooling

## Testing
- ⚠️ `pytest` *(dependencies could not be installed in the execution environment)*
- ⚠️ `npm run test -- --watch=false` *(dependencies could not be installed in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_b_690344d32e4c8321a8853e62db0c6f72